### PR TITLE
Issues and pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,23 +7,28 @@ assignees: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+## Bug Description
+Briefly describe the bug that you've encountered.
 
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Type '...'
-3. Run '...'
+## Expected Behavior
+What do you expect to happen? 
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+## Actual Behavior
+What behavior do you actually observe?
 
-**Screenshots / Exceptions / Errors**
-If applicable, add screenshots, exception stack traces, or error messages to help explain your problem.
+## Stack Trace
+If applicable, what was the stack trace printed to the console?
 
-**Canaveral Details (please complete the following information):**
- - Version: [e.g. 0.6.0]
 
-**Additional context**
-Add any other context about the problem here.
+## Steps to Reproduce the Problem
+
+  1.
+  2.
+  3.
+
+## Specifications
+
+  - Canaveral Version:
+  - Operating System:
+  - Shell:
+  

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG] <descrption of issue>"
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Type '...'
+3. Run '...'
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots / Exceptions / Errors**
+If applicable, add screenshots, exception stack traces, or error messages to help explain your problem.
+
+**Canaveral Details (please complete the following information):**
+ - Version: [e.g. 0.6.0]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEATURE] Feature request"
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? If yes, please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,18 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? If yes, please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+## Feature Request
+What feature would you like to see added to Canaveral?
+
+**Is your feature request related to a problem? If so, please describe it.**
+A clear and concise description of what the problem is. Ex. I have an issue when [...]
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+A clear and concise description of what you want to happen. Add any considered drawbacks.
 
 **Describe alternatives you've considered**
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+**Teachability, Documentation, Adoption, Migration Strategy**
+If you can, explain how users will be able to use this and possibly write out a version the docs.
+Maybe a screenshot or design?

--- a/.github/ISSUE_TEMPLATE/question---how-tos.md
+++ b/.github/ISSUE_TEMPLATE/question---how-tos.md
@@ -1,0 +1,12 @@
+---
+name: Question / How-Tos
+about: Ask a question
+title: "[QUESTION] General question"
+labels: question
+assignees: ''
+
+---
+
+I have a question that I don't think is related to a bug or feature request. 
+
+<Describe your question>

--- a/.github/ISSUE_TEMPLATE/question---how-tos.md
+++ b/.github/ISSUE_TEMPLATE/question---how-tos.md
@@ -7,6 +7,9 @@ assignees: ''
 
 ---
 
-I have a question that I don't think is related to a bug or feature request. 
+## Question
+I have a question about usage of Canaveral that isn't related to a bug or feature request...  
+Please describe your question as specifically as you can. If you really want to know one thing and ask another, you drastically increase the risk of running into the ![XY Problem](http://xyproblem.info/). Please try to avoid this whenever possible, for everyone's sake.
 
-<Describe your question>
+## Documentation Improvements
+If you believe that your question could be answered by the documentation better than it currently is, please include where you would expect to find it in the documentation.

--- a/.github/ISSUE_TEMPLATE/question---how-tos.md
+++ b/.github/ISSUE_TEMPLATE/question---how-tos.md
@@ -9,7 +9,7 @@ assignees: ''
 
 ## Question
 I have a question about usage of Canaveral that isn't related to a bug or feature request...  
-Please describe your question as specifically as you can. If you really want to know one thing and ask another, you drastically increase the risk of running into the ![XY Problem](http://xyproblem.info/). Please try to avoid this whenever possible, for everyone's sake.
+Please describe your question as specifically as you can. If you really want to know one thing and ask another, you drastically increase the risk of running into the [XY Problem](http://xyproblem.info/). Please try to avoid this whenever possible, for everyone's sake.
 
 ## Documentation Improvements
 If you believe that your question could be answered by the documentation better than it currently is, please include where you would expect to find it in the documentation.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,42 @@
+## Description
+
+Please include a brief summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Fixes Bug # (issue)
+Implements Feature Request # (issue)
+
+## Changes
+
+### User Facing Changes
+
+Please detail any changes that have been made that impact users. Specifically, what should users be aware of when using commands that are affected by your changes. List changes below.
+
+Changes (For example):
+- New command
+- New command alias
+
+### Dev Facing Changes
+
+Please detail any changes that have been made that impact developers. Specifically, what should developers be aware of when building on top of your changes. 
+
+Changes (For example):
+- New Dependencies
+- Changes to an interface
+
+## Testing
+
+Please describe the tests that you've added to verify that these features work correctly. No PR will be merged without tests being added and all (existing and new) tests passing.
+
+Tests should be written and passing for all platforms (Linux, Windows, and Mac). 
+
+## Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules
+- [ ] I have checked my code and corrected any misspellings


### PR DESCRIPTION
This change adds issues templates and PR templates. Unfortunately, because I'm not the creator of this repo I couldn't make them the recommended way, so we might have to debug them if they don't work once they're merged to master. However, in theory, once they're on master a contributor creating an issue should see three options: A bug report, a feature request, and a question. Additionally, someone creating a PR should see a template when they make their PR.